### PR TITLE
Post-Build - organize output artifacts into "lang" and "lib" subfolders.

### DIFF
--- a/WinLaunch/WinLaunch.csproj
+++ b/WinLaunch/WinLaunch.csproj
@@ -556,6 +556,10 @@
   -->
   <PropertyGroup>
     <PostBuildEvent>
-    </PostBuildEvent>
+for /f "tokens=*" %25%25G in ('dir /b /a:d "$(TargetDir)"') do ( if not "%25%25~NG" == "lib" if not "%25%25~NG" == "lang" if not "%25%25~NG" == "data"  RoboCopy "$(TargetDir)%25%25G " "$(TargetDir)lang\%25%25G " /E /IS /MOVE)
+
+RoboCopy "$(TargetDir) " "$(TargetDir)lib\ " /XF *.exe *.config *.manifext /XD lib lang data /E /IS /MOVE
+if %25errorlevel%25 leq 4 exit 0 else exit %25errorlevel%25
+</PostBuildEvent>
   </PropertyGroup>
 </Project>

--- a/WinLaunch/app.config
+++ b/WinLaunch/app.config
@@ -3,4 +3,9 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
   </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <probing privatePath="lang;lib" />
+    </assemblyBinding>
+  </runtime>
 </configuration>


### PR DESCRIPTION
Post-Build events to organize output artifacts into "lang" and "lib" subfolders.